### PR TITLE
make sure $hook_extra['plugins'] before using it.

### DIFF
--- a/inc/Clean.php
+++ b/inc/Clean.php
@@ -154,7 +154,11 @@ class Clean {
 				static::core_paths();
 				break;
 			case 'plugin':
-				static::plugin_paths( $hook_extra['plugins'] );
+				if ( isset( $hook_extra['plugins'] ) ) {
+					static::plugin_paths( $hook_extra['plugins'] );
+				} elseif ( isset( $hook_extra['plugin'] ) ) {
+					static::plugin_paths( array( $hook_extra['plugin'] ) );
+				}
 				break;
 			case 'theme':
 				static::theme_paths( $hook_extra['themes'] );


### PR DESCRIPTION
We've had some errors that `$hook_extra['plugins']` is not set when using it in this function.

It has only been with non WordPress.org plugins, but this should fix it to make sure that it is set before using it.

Also handle if `$hook_extra['plugin']` is used to pass a single plugin. A case that I have an example of the `$hook_extra` variable contained the following data.

```php
[
  'action' => 'update',
  'plugin' => 'wpmudev-updates/update-notifications.php',
  'type' => 'plugin'
]
```