### PR TITLE
Update paths list to match example docs.

### DIFF
--- a/inc/WPCLI.php
+++ b/inc/WPCLI.php
@@ -156,8 +156,8 @@ class WPCLI extends WP_CLI_Command {
 
 		$types = [ 'active', 'inactive', 'queue' ];
 
-		if ( isset( $assoc_args['type'] ) ) {
-			$types = array_intersect( explode( ',', $assoc_args['type'] ), $types );
+		if ( isset( $args[1] ) ) {
+			$types = array_intersect( explode( ',', $args[1] ), $types );
 		}
 
 		// Loop through types of paths.


### PR DESCRIPTION
With the current code using the commands in the example the last parameter (active, inactive, queue) had no effect using WP-CLI 2.1.0.

This updates the arg checked so that these options work.

	 *     # List paths that can be rewritten.
	 *     $ wp commonwp paths list active
	 *
	 *     # List paths that are not rewritten.
	 *     $ wp commonwp paths list inactive
	 *
	 *     # List paths that should be processed.
	 *     $ wp commonwp paths list queue